### PR TITLE
Fix ModelLoader issue - Double Parsing

### DIFF
--- a/Assets/Scripts/Loaders/ModelLoader.cs
+++ b/Assets/Scripts/Loaders/ModelLoader.cs
@@ -1,6 +1,7 @@
 ﻿
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEngine;
 
 public class ModelLoader {
@@ -32,7 +33,7 @@ public class ModelLoader {
         string version = Convert.ToString(data.ReadUByte());
         string subversion = Convert.ToString(data.ReadUByte());
         version += "." + subversion;
-        double dversion = double.Parse(version);
+        double dversion = double.Parse(version, CultureInfo.InvariantCulture);
         
         rsm.version = version;
         rsm.animLen = data.ReadLong();


### PR DESCRIPTION
As mentioned in #1, the problem was due to a parsing misusage inside `ModelLoader.cs`.
Adding `CultureInfo.InvariantCulture` seems to fix the issue.

It might not happen on your environment because of your pc settings