### PR TITLE
[Bugfix] Invalid guid in splash screen and UnityRO asmdef

### DIFF
--- a/Assets/Scenes/Splashscreen/SplashscreenScene.unity
+++ b/Assets/Scenes/Splashscreen/SplashscreenScene.unity
@@ -644,7 +644,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6849943526642155881}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1805d09c05763504eada15d431e2f07f, type: 3}
+  m_Script: {fileID: 11500000, guid: d2f02f07a4b4c0f4aa0da4d4b6d147a2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &6849943526642155885
@@ -656,6 +656,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 6849943526642155881}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6afd79fec31b4e048b62aaee3b715278, type: 3}
+  m_Script: {fileID: 11500000, guid: 0177030f90d5f9d4895377ad8047bb47, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Assets/UnityRO.asmdef
+++ b/Assets/UnityRO.asmdef
@@ -3,7 +3,7 @@
     "references": [
         "GUID:6055be8ebefd69e48b49212b09b47b2f",
         "GUID:8da2ed8a849f0c84e8e2fbf59ed26887",
-        "GUID:27a8f0f02e8bcc74e88c89ed99108c3a"
+        "GUID:243645cfb20d9c247a59fe2b5bc3be5f"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## Fix
fix Invalid Mono in Splash screen scene and compilation issues.

## Changes
Reserialized assets files: UnityRO.asmdef and SplashScreen.unity