### PR TITLE
[Bugfix] use ThreadManager instead of EntityManager in Splashscreen Scene

### DIFF
--- a/Assets/Scenes/Splashscreen/SplashscreenScene.unity
+++ b/Assets/Scenes/Splashscreen/SplashscreenScene.unity
@@ -656,6 +656,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 6849943526642155881}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0177030f90d5f9d4895377ad8047bb47, type: 3}
+  m_Script: {fileID: 11500000, guid: 1a241adbc512a5f4db071134318c9e33, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 


### PR DESCRIPTION
## Bug
ThreadManager was missing on Core game object

## Fix
Add missing component